### PR TITLE
fix(processor): qualify generated type_* property names with package

### DIFF
--- a/mockmp/mockmp-processor/src/main/kotlin/org/kodein/mock/ksp/MocKMPProcessor.kt
+++ b/mockmp/mockmp-processor/src/main/kotlin/org/kodein/mock/ksp/MocKMPProcessor.kt
@@ -159,14 +159,15 @@ public class MocKMPProcessor(
      * distinct type argument list (`fakeGenDataXIntX`, `fakeGenDataXStringX`, ...), nesting
      * (`fakeFakeTests_FakeAny` for a nested class `FakeAny` inside `FakeTests`) and nullability.
      */
-    private fun KSType.toFunName(): String {
-        val prefix = (if (isMarkedNullable) "Nul" else "") + declaration.parentPrefix()
+    private fun KSType.toFunName(includePackage: Boolean = false): String {
+        val packagePrefix = if (includePackage) declaration.packageName.asString().replace(".", "_") + "_" else ""
+        val prefix = packagePrefix + (if (isMarkedNullable) "Nul" else "") + declaration.parentPrefix()
         return prefix +
                 if (arguments.isEmpty()) declaration.simpleName.asString()
                 else "${declaration.simpleName.asString()}X${
                     arguments.joinToString("_") {
                         if (it.variance == Variance.STAR) "STAR"
-                        else it.type!!.resolve().toFunName()
+                        else it.type!!.resolve().toFunName(includePackage)
                     }
                 }X"
     }
@@ -989,13 +990,15 @@ public class MocKMPProcessor(
 
         /**
          * Generates the `fake(KType): T` dispatcher, with one `when` branch per faked type, keyed
-         * by a generated `private val type_Xxx: KType = typeOf<Xxx>()` (faked types can be generic,
-         * and `KType` equality — unlike [KClass] — accounts for type arguments):
+         * by a generated `private val type_pkg_Xxx: KType = typeOf<Xxx>()` (faked types can be
+         * generic, and `KType` equality — unlike [KClass] — accounts for type arguments). The
+         * package is included in the property name since all these properties live in the same
+         * generated file, and two distinct types can otherwise share a simple name:
          *
          * ```
-         * private val type_Foo: KType = typeOf<Foo>()
+         * private val type_foo_Foo: KType = typeOf<foo.Foo>()
          * internal actual fun <T : Any> fake(type: KType): T = when (type) {
-         *     type_Foo -> fakeFoo() as T
+         *     type_foo_Foo -> fakeFoo() as T
          *     else -> error("Could not find fake for type $type")
          * }
          * ```
@@ -1006,7 +1009,7 @@ public class MocKMPProcessor(
             val gFile = FileSpec.builder(accessorsPackage, "fakes")
             fakes.forEach { (type, _) ->
                 gFile.addProperty(
-                    PropertySpec.builder("type_${type.toFunName()}", KType::class)
+                    PropertySpec.builder("type_${type.toFunName(includePackage = true)}", KType::class)
                         .addModifiers(KModifier.PRIVATE)
                         .initializer("%M<%T>()", MemberName("kotlin.reflect", "typeOf"), type.toTypeName())
                         .build()
@@ -1020,7 +1023,7 @@ public class MocKMPProcessor(
 
             if (fakes.isNotEmpty()) {
                 gFun.beginControlFlow("return when (type)")
-                fakes.forEach { (type, fake) -> gFun.addStatement("type_${type.toFunName()} -> %M() as T", fake) }
+                fakes.forEach { (type, fake) -> gFun.addStatement("type_${type.toFunName(includePackage = true)} -> %M() as T", fake) }
                 gFun.addStatement("else -> error(\"Could not find fake for type \$type\")")
                 gFun.endControlFlow()
             } else {

--- a/tests-projects/tests-mp-junit4/src/commonMain/kotlin/foo/Data.kt
+++ b/tests-projects/tests-mp-junit4/src/commonMain/kotlin/foo/Data.kt
@@ -1,0 +1,5 @@
+package foo
+
+data class Data(
+    val value: String
+)

--- a/tests-projects/tests-mp-junit4/src/commonTest/kotlin/tests/InjectionTests.kt
+++ b/tests-projects/tests-mp-junit4/src/commonTest/kotlin/tests/InjectionTests.kt
@@ -19,6 +19,9 @@ class InjectionTests : TestsWithMocks() {
     lateinit var data: Data
 
     @Fake
+    lateinit var fooData: foo.Data
+
+    @Fake
     lateinit var arrays: Arrays
 
     @Fake
@@ -41,6 +44,7 @@ class InjectionTests : TestsWithMocks() {
     fun testMockInjection() {
         assertNotNull(bar)
         assertNotNull(data)
+        assertNotNull(fooData)
         assertNotNull(arrays)
         assertNotNull(funs)
         assertNotNull(callback)


### PR DESCRIPTION
## Summary
- The `fake(KType): T` dispatcher generated in `fakes.kt` declares one `private val type_Xxx: KType` per faked type. These were named from the simple type name only, so two distinct `@Fake`-able types sharing a simple name across different packages (e.g. `data.Data` and `foo.Data`) generated colliding property names in the same file, breaking compilation.
- Fix: `KSType.toFunName()` now takes an `includePackage` flag; the `type_*` property names (and their generic type-argument components) are qualified with the declaration's package, e.g. `type_data_Data` / `type_foo_Data`. The `fakeXxx()`/`mockXxx()` function naming is untouched since those already live in separate per-package files.

## Test plan
- [x] Added a `foo.Data` class alongside the existing `data.Data` in `tests-mp-junit4`, and a `@Fake fooData: foo.Data` in `InjectionTests`, reproducing the collision.
- [x] `./gradlew :tests-mp-junit4:compileTestKotlinJvm` succeeds.
- [x] `./gradlew :tests-mp-junit4:jvmTest --tests tests.InjectionTests` passes.
- [x] Verified generated `fakes.kt` now emits distinct `type_data_Data` and `type_foo_Data` properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)